### PR TITLE
Add modify_fluid_recipe to allow modification of fluid recipes

### DIFF
--- a/prototypes/recipe-final-fixes.lua
+++ b/prototypes/recipe-final-fixes.lua
@@ -34,7 +34,7 @@ local function can_modify_recipe(recipe)
     return false
   end
 
-  local recipe_metadata = ScrapIndustry.recipes[recipe.name]
+  local recipe_metadata = ScrapIndustry.recipes[recipe.name] or {}
   if recipe_metadata then
     -- ignore=false forces a recipe to be modified, even if the category is ignored
     if type(recipe_metadata.ignore) == "boolean" then
@@ -61,6 +61,9 @@ local function can_modify_recipe(recipe)
     if result.type == "item" then
       return true
     end
+    if result.type == "fluid" and recipe_metadata.modify_fluid_recipe then
+	    return true
+	  end
   end
   return false
 end

--- a/prototypes/recipe-final-fixes.lua
+++ b/prototypes/recipe-final-fixes.lua
@@ -61,7 +61,7 @@ local function can_modify_recipe(recipe)
     if result.type == "item" then
       return true
     end
-    if result.type == "fluid" and recipe_metadata.modify_fluid_recipe then
+    if result.type == "fluid" and recipe_metadata.force then
 	    return true
 	  end
   end


### PR DESCRIPTION
You probably have a good reason for generally not trying to modify recipes that only return fluids, but I needed to do it, so I added an option to allow it.